### PR TITLE
Loop over multiple image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently the following tasks are available:
 
 1. Install the package in dev mode with `python -m pip install -e ".[dev]"`
 2. Develop the function according to the [Fractal API](https://fractal-analytics-platform.github.io/version_2/)
-3. Update the image list and the Fractal manifest with `python src/operio_fractal/dev/create_manifest.py`
+3. Update the image list and the Fractal manifest with `python src/operetta_compose/dev/create_manifest.py`
 4. Build a wheel file in the `dist` folder of the package with `python -m build`
 5. Collect the tasks on a Fractal server
 

--- a/src/operetta_compose/__FRACTAL_MANIFEST__.json
+++ b/src/operetta_compose/__FRACTAL_MANIFEST__.json
@@ -22,12 +22,15 @@
           "zarr_dir": {
             "title": "Zarr Dir",
             "type": "string",
-            "description": "Path to the new OME-ZARR output directory"
+            "description": "Path to the new OME-ZARR output directory where the zarr plates should be saved. The zarr plates are extracted from the image paths"
           },
-          "img_path": {
-            "title": "Img Path",
-            "type": "string",
-            "description": "Path to the input directory with the image files"
+          "img_paths": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Img Paths",
+            "type": "array",
+            "description": "Paths to the input directories with the image files"
           },
           "overwrite": {
             "default": false,
@@ -51,7 +54,7 @@
         "required": [
           "zarr_urls",
           "zarr_dir",
-          "img_path"
+          "img_paths"
         ],
         "type": "object",
         "title": "HarmonyToOmeZarr"

--- a/src/operetta_compose/tasks/stardist_segmentation.py
+++ b/src/operetta_compose/tasks/stardist_segmentation.py
@@ -52,7 +52,8 @@ def stardist_segmentation(
         overwrite: Whether to overwrite any existing OME-ZARR segmentations
     """
     model_loaded = False
-    while not model_loaded:
+    count = 0
+    while not model_loaded and count < 5:
         try:
             if "3D" in stardist_model:
                 model = StarDist3D.from_pretrained(stardist_model)
@@ -62,6 +63,7 @@ def stardist_segmentation(
                 model_loaded = True
         except:
             time.sleep(random.uniform(2, 7))
+            count += 1
 
     roi = 0
     curr_roi_max = 0


### PR DESCRIPTION
Allows to consolidate multiple zarr plates into one `zarr_dir` by looping over multiple image directories from which the respective plate name is extracted.