### PR TITLE
Select feature subset & reorder as expected by classifier

### DIFF
--- a/src/operetta_compose/tasks/feature_classification.py
+++ b/src/operetta_compose/tasks/feature_classification.py
@@ -49,6 +49,11 @@ def feature_classification(
         ann_tbl.obs["roi_id"] = f"{zarr_url}:" + roi_id_cols.astype(str).agg(
             ":".join, axis=1
         )
+
+    # Select feature subset in expected order
+    features = features[clf.get_feature_names()]
+
+    # Add index columns
     features_with_annotations = pd.concat(
         (ann_tbl.obs[["roi_id", "label"]], features), axis=1
     )


### PR DESCRIPTION
Hey @fdsteffen 

The PR https://github.com/leukemia-kispi/operetta-compose/pull/15 looks good. In my tests, I've found some issues with subset of features & their ordering, depending on how the classifier was trained. This change should ensure that we always load the features in the expected column order to avoid issues when running the prediction afterwards.

Besides that, looks great to me, let's merge and release! =D

Thanks a lot for the 2 quick fixes!