### PR TITLE
Add task metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
 
 
   pypi-publish:
-    if: startsWith(github.ref, 'refs/tags')
+    needs: test-deploy
+    if: success() && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs:
       - test-deploy
@@ -74,3 +75,8 @@ jobs:
 
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: './dist/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
       - test-deploy
     permissions:
       id-token: write
+      # This permission allows writing releases
+      contents: write
     environment:
       name: pypi
       url: https://pypi.org/p/operetta-compose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - uses: softprops/action-gh-release@v2
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: './dist/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
 
 
   pypi-publish:
-    needs: test-deploy
     if: success() && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs:

--- a/src/operetta_compose/__FRACTAL_MANIFEST__.json
+++ b/src/operetta_compose/__FRACTAL_MANIFEST__.json
@@ -3,6 +3,13 @@
   "task_list": [
     {
       "name": "Harmony to OME-Zarr",
+      "category": "Conversion",
+      "modality": "HCS",
+      "tags": [
+        "Opera",
+        "Operetta",
+        "Perkin Elmer"
+      ],
       "executable_non_parallel": "tasks/harmony_to_ome_zarr.py",
       "meta_non_parallel": {
         "cpus_per_task": 1,
@@ -146,6 +153,7 @@
     },
     {
       "name": "Stardist segmentation",
+      "category": "Segmentation",
       "executable_parallel": "tasks/stardist_segmentation.py",
       "meta_parallel": {
         "cpus_per_task": 4,
@@ -243,6 +251,12 @@
     },
     {
       "name": "Regionprops measurement",
+      "category": "Measurement",
+      "tags": [
+        "regionprops",
+        "intensity",
+        "morphology"
+      ],
       "executable_parallel": "tasks/regionprops_measurement.py",
       "meta_parallel": {
         "cpus_per_task": 1,
@@ -292,6 +306,10 @@
     },
     {
       "name": "Feature classification",
+      "tags": [
+        "napari feature classifier",
+        "object classification"
+      ],
       "executable_parallel": "tasks/feature_classification.py",
       "meta_parallel": {
         "cpus_per_task": 1,
@@ -330,11 +348,16 @@
         "type": "object",
         "title": "FeatureClassification"
       },
-      "docs_info": "## feature_classification\nClassify cells using the [napari-feature-classifier](https://github.com/fractal-napari-plugins-collection/napari-feature-classifier)\nand write them to the OME-ZARR\n",
+      "docs_info": "## feature_classification\nClassify cells using the [napari-feature-classifier](https://github.com/fractal-napari-plugins-collection/napari-feature-classifier) and write them to the OME-ZARR\n",
       "docs_link": "https://leukemia-kispi.github.io/operetta-compose/"
     },
     {
       "name": "Condition registration",
+      "modality": "HCS",
+      "tags": [
+        "Metadata",
+        "Treatment conditions"
+      ],
       "executable_parallel": "tasks/condition_registration.py",
       "meta_parallel": {
         "cpus_per_task": 1,
@@ -378,5 +401,6 @@
     }
   ],
   "has_args_schemas": true,
-  "args_schema_version": "pydantic_v2"
+  "args_schema_version": "pydantic_v2",
+  "authors": "Fabio Steffen"
 }

--- a/src/operetta_compose/dev/create_manifest.py
+++ b/src/operetta_compose/dev/create_manifest.py
@@ -2,8 +2,10 @@ from fractal_tasks_core.dev.create_manifest import create_manifest
 from operetta_compose import PACKAGE
 
 if __name__ == "__main__":
+    AUTHORS="Fabio Steffen"
     create_manifest(
         package=PACKAGE,
+        authors=AUTHORS,
         docs_link="https://leukemia-kispi.github.io/operetta-compose/",
         custom_pydantic_models=[
             ("operetta_compose.io", "__init__.py", "OmeroNgffWindow"),

--- a/src/operetta_compose/dev/task_list.py
+++ b/src/operetta_compose/dev/task_list.py
@@ -5,25 +5,34 @@ TASK_LIST = [
         name="Harmony to OME-Zarr",
         executable="tasks/harmony_to_ome_zarr.py",
         meta={"cpus_per_task": 1, "mem": 4000},
+        category="Conversion",
+        modality="HCS",
+        tags=["Opera", "Operetta", "Perkin Elmer"],
     ),
     ParallelTask(
         name="Stardist segmentation",
         executable="tasks/stardist_segmentation.py",
         meta={"cpus_per_task": 4, "mem": 16000, "needs_gpu": True},
+        category="Segmentation",
     ),
     ParallelTask(
         name="Regionprops measurement",
         executable="tasks/regionprops_measurement.py",
         meta={"cpus_per_task": 1, "mem": 4000},
+        category="Measurement",
+        tags=["regionprops", "intensity", "morphology"]
     ),
     ParallelTask(
         name="Feature classification",
         executable="tasks/feature_classification.py",
         meta={"cpus_per_task": 1, "mem": 4000},
+        tags=["napari feature classifier", "object classification"]
     ),
     ParallelTask(
         name="Condition registration",
         executable="tasks/condition_registration.py",
         meta={"cpus_per_task": 1, "mem": 4000},
+        modality="HCS",
+        tags=["Metadata", "Treatment conditions"]
     ),
 ]

--- a/src/operetta_compose/dev/task_list.py
+++ b/src/operetta_compose/dev/task_list.py
@@ -20,19 +20,19 @@ TASK_LIST = [
         executable="tasks/regionprops_measurement.py",
         meta={"cpus_per_task": 1, "mem": 4000},
         category="Measurement",
-        tags=["regionprops", "intensity", "morphology"]
+        tags=["regionprops", "intensity", "morphology"],
     ),
     ParallelTask(
         name="Feature classification",
         executable="tasks/feature_classification.py",
         meta={"cpus_per_task": 1, "mem": 4000},
-        tags=["napari feature classifier", "object classification"]
+        tags=["napari feature classifier", "object classification"],
     ),
     ParallelTask(
         name="Condition registration",
         executable="tasks/condition_registration.py",
         meta={"cpus_per_task": 1, "mem": 4000},
         modality="HCS",
-        tags=["Metadata", "Treatment conditions"]
+        tags=["metadata", "well conditions", "perturbation", "treatment"],
     ),
 ]


### PR DESCRIPTION
Hey @fdsteffen 

We're adding metadata to the tasks to be able to build better task interfaces. I've created this PR to show how this metadata is structured. The core fields for each task are:

1. Category: Conversion, Segmentation, Registration, Measurement, Image Processing
2. Modality: HCS, lightsheet, EM
3. Tags: Arbitrary strings that are searchable and provide info about the task

Category & Modality work by convention, but you can add new entries when useful.

Additionally, there is now an "authors" field for the whole package.

In order for the future public Fractal page to list your tasks (see https://github.com/fractal-analytics-platform/fractal-analytics-platform.github.io/issues/6), the package needs to either be on PyPI or have github releases with whl files. As part of this PR, I'm adding a step to the Github CI that creates a release with whl files upon tags. Let me know if that works for you.

---

What remains to be done:

1. Check whether my suggestions in the image list make sense
2. Add additional metadata, e.g. more tags
3. Decide whether the whl releases is something you want
4. Merge & release ;)