### PR TITLE
Refactor feature_classification task to use ngio & do safe combination of dfs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = ["fractal-tasks-core",
                 "stardist",
                 "tensorflow",
                 "tensorflow-metal ; platform_system == 'Darwin'",
-                "napari-feature-classifier"
+                "napari-feature-classifier",
+                "ngio==0.1.4",
                ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 # Required Python version and dependencies
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["fractal-tasks-core",
                 "ome-zarr",
                 "imagecodecs",

--- a/src/operetta_compose/__FRACTAL_MANIFEST__.json
+++ b/src/operetta_compose/__FRACTAL_MANIFEST__.json
@@ -333,12 +333,6 @@
             "title": "Table Name",
             "type": "string",
             "description": "Folder name of the measured regionprobs features"
-          },
-          "label_name": {
-            "default": "nuclei",
-            "title": "Label Name",
-            "type": "string",
-            "description": "Name of the labels to use for feature measurements"
           }
         },
         "required": [
@@ -355,8 +349,10 @@
       "name": "Condition registration",
       "modality": "HCS",
       "tags": [
-        "Metadata",
-        "Treatment conditions"
+        "metadata",
+        "well conditions",
+        "perturbation",
+        "treatment"
       ],
       "executable_parallel": "tasks/condition_registration.py",
       "meta_parallel": {

--- a/src/operetta_compose/tasks/feature_classification.py
+++ b/src/operetta_compose/tasks/feature_classification.py
@@ -43,10 +43,10 @@ def feature_classification(
         remove_roi_id_column = True
 
     # Select feature subset in expected order
-    features = features[clf.get_feature_names() + index_columns]
+    features_subset = features[clf.get_feature_names() + index_columns]
 
     # Run predictions
-    predictions = clf.predict(features).reset_index()
+    predictions = clf.predict(features_subset).reset_index()
 
     # Fuse into existing feature table
     features_with_predictions = features.merge(

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -82,7 +82,6 @@ def test_predict():
         zarr_url=str(ZARR_DIR.joinpath(PLATE_ZARR, "C", "3", "0")),
         classifier_path=str(Path(TEST_DIR).joinpath("fixtures", "classifier.pkl")),
         table_name="regionprops",
-        label_name="nuclei",
     )
 
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 import zarr
+import ngio
 
 from fractal_tasks_core.channels import ChannelInputModel
 
@@ -78,11 +79,24 @@ def test_measure():
 @pytest.mark.dependency(depends=["test_converter", "test_stardist", "test_measure"])
 # @pytest.mark.skip
 def test_predict():
+    zarr_url = str(ZARR_DIR.joinpath(PLATE_ZARR, "C", "3", "0"))
+    table_name = "regionprops"
+    img_pre = ngio.NgffImage(zarr_url)
+    table_pre = img_pre.tables.get_table(table_name)
+    initial_shape = table_pre.table.shape
+    target_table_shape = (initial_shape[0], initial_shape[1] + 1)
+
     feature_classification(
-        zarr_url=str(ZARR_DIR.joinpath(PLATE_ZARR, "C", "3", "0")),
+        zarr_url=zarr_url,
         classifier_path=str(Path(TEST_DIR).joinpath("fixtures", "classifier.pkl")),
-        table_name="regionprops",
+        table_name=table_name,
     )
+
+    # Check that the task adds exactly 1 column named prediction to the table
+    img = ngio.NgffImage(zarr_url)
+    new_table = img.tables.get_table(table_name).table
+    assert new_table.shape==target_table_shape
+    assert 'prediction' in new_table.columns
 
 
 @pytest.mark.dependency(depends=["test_converter"])


### PR DESCRIPTION
@fdsteffen I'm proposing a rewrite of the feature classification task here, as the current handling lead to issues in https://github.com/leukemia-kispi/operetta-compose/issues/18.

When working on a rewrite, I decided it would likely be easier to do this with ngio. We can of course port the dataframe merging fixes back to avoid using ngio and having to depend on it. But I try to move more of my task packages over to ngio now, so maybe it's a good start to have this as a first task in operetta-compose :)
Depending on ngio would come with the side-effect of having to raise minimum Python to 3.10

I will test this branch on a real deployment first before I suggest we'd merge that (=> draft PR).