### PR TITLE
Classifier updates: Expose naming & store class names instead of integers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .[dev]
-          pytest
 
       - name: Regenerate the manifest
         run: python src/operetta_compose/dev/create_manifest.py
@@ -40,13 +39,13 @@ jobs:
       - name: Check if manifest has changed
         run: |
           if [ -n "$(git diff --exit-code ./src/operetta_compose/__FRACTAL_MANIFEST__.json)" ]; then
-          echo "__FRACTAL_MANIFEST__.json has changed. Please run 'python src/fractal_helper_tasks/dev/create_manifest.py' and commit the changes."
+          echo "__FRACTAL_MANIFEST__.json has changed. Please run 'python src/operetta_compose/dev/create_manifest.py' and commit the changes."
             exit 1
           else
             echo "__FRACTAL_MANIFEST__.json has not changed."
           fi
 
-      - name: Runt ests
+      - name: Run tests
         run: |
           pytest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,26 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Test package
+      - name: Install dependencies
         run: |
           pip install -e .[dev]
           pytest
 
+      - name: Regenerate the manifest
+        run: python src/operetta_compose/dev/create_manifest.py
+
+      - name: Check if manifest has changed
+        run: |
+          if [ -n "$(git diff --exit-code ./src/operetta_compose/__FRACTAL_MANIFEST__.json)" ]; then
+          echo "__FRACTAL_MANIFEST__.json has changed. Please run 'python src/fractal_helper_tasks/dev/create_manifest.py' and commit the changes."
+            exit 1
+          else
+            echo "__FRACTAL_MANIFEST__.json has not changed."
+          fi
+
+      - name: Runt ests
+        run: |
+          pytest
 
 
   pypi-publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = ["fractal-tasks-core",
                 "tensorflow",
                 "tensorflow-metal ; platform_system == 'Darwin'",
                 "napari-feature-classifier",
-                "ngio==0.1.4",
+                "ngio==0.1.6",
                ]
 
 

--- a/src/operetta_compose/__FRACTAL_MANIFEST__.json
+++ b/src/operetta_compose/__FRACTAL_MANIFEST__.json
@@ -333,6 +333,11 @@
             "title": "Table Name",
             "type": "string",
             "description": "Folder name of the measured regionprobs features"
+          },
+          "classifier_name": {
+            "title": "Classifier Name",
+            "type": "string",
+            "description": "Name of the classification results to be written to the feature table. It will default to the name of the classifier + \"_prediction\" when left unset."
           }
         },
         "required": [

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -95,8 +95,24 @@ def test_predict():
     # Check that the task adds exactly 1 column named prediction to the table
     img = ngio.NgffImage(zarr_url)
     new_table = img.tables.get_table(table_name).table
+    assert set(['Viable leukemia cells', 'MSC', 'Dead cells']) == set(new_table["classifier_prediction"].unique())
     assert new_table.shape==target_table_shape
-    assert 'prediction' in new_table.columns
+
+    # Run a second classifier with a defined output name
+    target_table_shape = (initial_shape[0], initial_shape[1] + 2)
+
+    feature_classification(
+        zarr_url=zarr_url,
+        classifier_path=str(Path(TEST_DIR).joinpath("fixtures", "classifier.pkl")),
+        table_name=table_name,
+        classifier_name="cell_classifier_result"
+    )
+
+    # Check that the task adds exactly 1 column named prediction to the table
+    img = ngio.NgffImage(zarr_url)
+    new_table = img.tables.get_table(table_name).table
+    assert set(['Viable leukemia cells', 'MSC', 'Dead cells']) == set(new_table["cell_classifier_result"].unique())
+    assert new_table.shape==target_table_shape
 
 
 @pytest.mark.dependency(depends=["test_converter"])


### PR DESCRIPTION
This closes #20 

It exposes a new input variable `classifier_name` that a user can optionally set to give the classifier column a specific name. If left unset, the filename of the classifier is used, any non characters/numbers are replaced by _, the file ending is removed and `_prediction` is added.

Additionally, the prediction column now saves the names of the classes, not their integers, simplifying the interpretation of the classification results.