### PR TITLE
Handle NA predictions in classifier task

### DIFF
--- a/src/operetta_compose/tasks/feature_classification.py
+++ b/src/operetta_compose/tasks/feature_classification.py
@@ -57,7 +57,6 @@ def feature_classification(
 
     # Run predictions & save name of prediction in dataframe
     predictions = clf.predict(features_subset).reset_index()
-    # predictions[classifier_name] = predictions['prediction'].map(lambda x: clf._class_names[x - 1])
     predictions[classifier_name] = predictions['prediction'].map(
         lambda x: clf._class_names[int(x) - 1] if pd.notna(x) else "NaN"
     )

--- a/src/operetta_compose/tasks/feature_classification.py
+++ b/src/operetta_compose/tasks/feature_classification.py
@@ -57,7 +57,10 @@ def feature_classification(
 
     # Run predictions & save name of prediction in dataframe
     predictions = clf.predict(features_subset).reset_index()
-    predictions[classifier_name] = predictions['prediction'].map(lambda x: clf._class_names[x - 1])
+    # predictions[classifier_name] = predictions['prediction'].map(lambda x: clf._class_names[x - 1])
+    predictions[classifier_name] = predictions['prediction'].map(
+        lambda x: clf._class_names[int(x) - 1] if pd.notna(x) else "NaN"
+    )
     predictions = predictions.drop(columns="prediction")
 
     # Fuse into existing feature table


### PR DESCRIPTION
## Description of changes

Currently, the classifier task fails to correctly map names when any predictions are NA and fails with an `TypeError: list indices must be integers or slices, not float`. This addresses this issue. I'm testing it on some larger real datasets now :)

## Checklist

- [x] Linting passes locally using the precommit hook
- [x] Unit / Integration tests with pytest have been added
- [x] Function documentation has been updated
